### PR TITLE
LOD crash fix. 

### DIFF
--- a/code/render/lighting/environmentprobe.h
+++ b/code/render/lighting/environmentprobe.h
@@ -53,6 +53,7 @@ private:
 inline void
 EnvironmentProbe::AssignReflectionMap(const Ptr<Resources::ManagedTexture>& refl)
 {
+	n_assert(refl.isvalid());
 	this->reflectionMap = refl;
 }
 
@@ -62,6 +63,7 @@ EnvironmentProbe::AssignReflectionMap(const Ptr<Resources::ManagedTexture>& refl
 inline void
 EnvironmentProbe::AssignIrradianceMap(const Ptr<Resources::ManagedTexture>& irr)
 {
+	n_assert(irr.isvalid());
 	this->irradianceMap = irr;
 }
 

--- a/code/toolkit/toolkitutil/fbx/nfbxexporter.cc
+++ b/code/toolkit/toolkitutil/fbx/nfbxexporter.cc
@@ -270,8 +270,6 @@ NFbxExporter::StartExport( const IO::URI& file )
 	this->sceneWriter->SetScene(this->scene);
 	this->sceneWriter->SetPlatform(this->platform);
 
-	this->fbxScene->Clear();
-	this->fbxScene = 0;
 	return true;
 }
 
@@ -292,6 +290,8 @@ NFbxExporter::EndExport()
 
 	// cleanup data
 	this->scene->Cleanup();
+	this->fbxScene->Clear();
+	this->fbxScene = 0;
 }
 
 //------------------------------------------------------------------------------

--- a/code/toolkit/toolkitutil/fbx/node/nfbxmeshnode.cc
+++ b/code/toolkit/toolkitutil/fbx/node/nfbxmeshnode.cc
@@ -99,11 +99,6 @@ NFbxMeshNode::Setup( FbxNode* node, const Ptr<NFbxScene>& scene )
 	if (this->fbxNode->GetParent())
 	{
 		this->lod = this->fbxNode->GetParent()->GetLodGroup();
-		if (this->lod != NULL)
-		{
-			int numThresholds = this->lod->GetNumThresholds();
-			int displayLevels = this->lod->GetNumDisplayLevels();
-		}
 	}
 
 	// set mask
@@ -1030,6 +1025,14 @@ NFbxMeshNode::DoMerge( Util::Dictionary<Util::String, Util::Array<Ptr<NFbxMeshNo
 		this->skinFragments.Clear();
 	}
 
+	// make sure lods doesn't get merged
+	if (this->lod != NULL)
+	{
+		String lodMaterial;
+		lodMaterial.Format("_lod_%d_%d", this->lodIndex, this->name.HashCode());
+		this->material.Append(lodMaterial);
+	}
+
 	// add this mesh to mesh dictionary, create entry if non-existent
 	if (meshes.Contains(this->material))
 	{
@@ -1051,13 +1054,10 @@ NFbxMeshNode::DoMerge( Util::Dictionary<Util::String, Util::Array<Ptr<NFbxMeshNo
 const float 
 NFbxMeshNode::GetLODMaxDistance() const
 {
+	n_assert(this->lod != NULL);
 	FbxDistance dist;
-	int index = this->lodIndex;
-	bool hasMax = false;
-	if (index >= 0)
-	{
-		hasMax = this->lod->GetThreshold(index, dist);
-	}
+	int index = n_iclamp(this->lodIndex, 0, this->lod->GetNumThresholds());
+	bool hasMax = this->lod->GetThreshold(index, dist);
 
 	float scale = this->scene->GetScale();
 	if (hasMax)
@@ -1077,13 +1077,10 @@ NFbxMeshNode::GetLODMaxDistance() const
 const float 
 NFbxMeshNode::GetLODMinDistance() const
 {
+	n_assert(this->lod != NULL);
 	FbxDistance dist;
-	int index = this->lodIndex - 1;
-	bool hasMin = false;
-	if (index >= 0)
-	{
-		hasMin = this->lod->GetThreshold(index, dist);
-	}
+	int index = n_iclamp(this->lodIndex - 1, 0, this->lod->GetNumThresholds());
+	bool hasMin = this->lod->GetThreshold(index, dist);
 
 	float scale = this->scene->GetScale();
 	if (hasMin)

--- a/code/toolkit/toolkitutil/fbx/node/nfbxmeshnode.cc
+++ b/code/toolkit/toolkitutil/fbx/node/nfbxmeshnode.cc
@@ -96,9 +96,13 @@ NFbxMeshNode::Setup( FbxNode* node, const Ptr<NFbxScene>& scene )
 	}
 
 	// get lod group
-	if (this->fbxNode->GetParent())
+	if (this->fbxNode->GetParent() != NULL)
 	{
 		this->lod = this->fbxNode->GetParent()->GetLodGroup();
+		if (!this->lod->Is(FbxLODGroup::ClassId))
+		{
+			this->lod = NULL;
+		}
 	}
 
 	// set mask
@@ -1056,19 +1060,20 @@ NFbxMeshNode::GetLODMaxDistance() const
 {
 	n_assert(this->lod != NULL);
 	FbxDistance dist;
-	int index = n_iclamp(this->lodIndex, 0, this->lod->GetNumThresholds());
-	bool hasMax = this->lod->GetThreshold(index, dist);
+	int index = n_max(this->lodIndex, -1);
+	if (index >= 0)
+	{
+		bool hasMax = this->lod->GetThreshold(index, dist);
 
-	float scale = this->scene->GetScale();
-	if (hasMax)
-	{
-		return dist.value() * scale;
+		float scale = this->scene->GetScale();
+		if (hasMax)
+		{
+			return dist.value() * scale;
+		}
 	}
-	else
-	{
-		// if this is our last node, set the max value to float max
-		return FLT_MAX;
-	}
+
+	// fallback in case we don't have an interval
+	return FLT_MAX;
 }
 
 //------------------------------------------------------------------------------
@@ -1079,19 +1084,20 @@ NFbxMeshNode::GetLODMinDistance() const
 {
 	n_assert(this->lod != NULL);
 	FbxDistance dist;
-	int index = n_iclamp(this->lodIndex - 1, 0, this->lod->GetNumThresholds());
-	bool hasMin = this->lod->GetThreshold(index, dist);
+	int index = n_max(this->lodIndex - 1, -1);
+	if (index >= 0)
+	{
+		bool hasMin = this->lod->GetThreshold(index, dist);
 
-	float scale = this->scene->GetScale();
-	if (hasMin)
-	{
-		return dist.value() * scale;
+		float scale = this->scene->GetScale();
+		if (hasMin)
+		{
+			return dist.value() * scale;
+		}
 	}
-	else
-	{
-		// if we have no min-value, the smallest value must be 0...
-		return 0.0f;
-	}
+
+	// if we have no min-value, the smallest value must be 0...
+	return 0.0f;
 }
 
 } // namespace ToolkitUtil

--- a/code/toolkit/toolkitutil/fbx/node/nfbxmeshnode.cc
+++ b/code/toolkit/toolkitutil/fbx/node/nfbxmeshnode.cc
@@ -99,10 +99,6 @@ NFbxMeshNode::Setup( FbxNode* node, const Ptr<NFbxScene>& scene )
 	if (this->fbxNode->GetParent() != NULL)
 	{
 		this->lod = this->fbxNode->GetParent()->GetLodGroup();
-		if (!this->lod->Is(FbxLODGroup::ClassId))
-		{
-			this->lod = NULL;
-		}
 	}
 
 	// set mask

--- a/code/toolkit/toolkitutil/fbx/node/nfbxscene.cc
+++ b/code/toolkit/toolkitutil/fbx/node/nfbxscene.cc
@@ -499,16 +499,13 @@ NFbxScene::Flatten()
 		}
 		
 		// get list of meshes for material
-		Array<Ptr<NFbxMeshNode> > meshList = meshNodes.ValueAtIndex(i);
-
-		// create list of lod nodes
-		Array<Ptr<NFbxMeshNode> > lodList;
+		Array<Ptr<NFbxMeshNode>> meshList = meshNodes.ValueAtIndex(i);
 
 		// treat first mesh as the root for which we should merge the others to
 		Ptr<NFbxMeshNode> rootMesh = meshList[0];
 
 		// create new list of fragments
-		Array<Ptr<SkinFragment> > rootFragments;
+		Array<Ptr<SkinFragment>> rootFragments;
 		String nodeName;
 
 		// begin bounding box extending, this should be cheaper than a complete recalculation
@@ -518,24 +515,11 @@ NFbxScene::Flatten()
 		// create counter for physics
 		IndexT physicsNodeIndex = 0;
 
-		// keep track of if the last node as a LODded node
-		bool previousWasLOD = false;
-
 		IndexT k;
 		for (k = 0; k < meshList.Size(); k++)
 		{
 			Ptr<NFbxMeshNode> meshNode = meshList[k];
 			meshNode->SetGroupId(groupIndex);
-
-			// add node to lod list
-			if (meshNode->HasLOD())
-			{
-				lodList.Append(meshNode);
-			}
-			else if (previousWasLOD)
-			{
-				groupIndex++;
-			}
 
 			// add physics node to list of physics nodes
 			if (physics)
@@ -554,7 +538,7 @@ NFbxScene::Flatten()
 			IndexT triIndex;
 
 			// get list of fragments
-			const Util::Array<Ptr<SkinFragment> >& fragments = meshNode->GetSkinFragments();
+			const Util::Array<Ptr<SkinFragment>>& fragments = meshNode->GetSkinFragments();
 
 			// extend bounding box
 			mergedBox.extend(meshNode->GetBoundingBox());
@@ -626,17 +610,6 @@ NFbxScene::Flatten()
 				rootMeshSource->AddTriangle(tri);
 			}
 
-			// increase group index if we have lod
-			if (meshNode->HasLOD())
-			{
-				groupIndex++;
-				previousWasLOD = true;
-			}
-			else
-			{
-				previousWasLOD = false;
-			}
-
 			if (physics)
 			{
 				physicsGroupIndex++;
@@ -669,27 +642,12 @@ NFbxScene::Flatten()
 			// add mesh back
 			meshList.Append(rootMesh);
 
-			// add lod meshes back
-			meshList.AppendArray(lodList);
-
 			// now set list back
 			meshNodes[meshNodes.KeyAtIndex(i)] = meshList;
 
-			// add lod nodes if present
-			if (!lodList.IsEmpty())
-			{
-				IndexT k;
-				for (k = 0; k < lodList.Size(); k++)
-				{
-					this->meshNodes.Add(rootMesh->GetNode(), lodList[k]);
-				}
-			}
-			else
-			{
-				// add merged node to dictionaries
-				this->meshNodes.Add(rootMesh->GetNode(), rootMesh);
-			}
-			
+			// add merged node to dictionaries
+			this->meshNodes.Add(rootMesh->GetNode(), rootMesh);
+
 			this->nodes.Add(rootMesh->GetNode(), rootMesh.upcast<NFbxNode>());		
 			this->rootNodes.Append(rootMesh.upcast<NFbxNode>());
 		}


### PR DESCRIPTION
Fixed the crash where LOD groups would get unloaded before they got read. Also, cleaned up the LOD scene creation part to make it less ugly and forced, which however ensures all elements in a LOD group will have its own material (which should be fine, since it becomes a unique draw call anyways). 
